### PR TITLE
Create lein projects, bump dependency versions

### DIFF
--- a/kr-core/project.clj
+++ b/kr-core/project.clj
@@ -5,6 +5,6 @@
                    :only-deps [org.clojure/clojure
                                org.clojure/java.classpath
                                com.stuartsierra/dependency]}
-  :plugins [[lein-parent-mg "0.2.2"]]
+  :plugins [[lein-parent "0.2.1"]]
   :source-paths ["src/main/clojure" "src/test/clojure"]
   :test-paths ["src/test/clojure"])

--- a/kr-core/project.clj
+++ b/kr-core/project.clj
@@ -1,6 +1,5 @@
 (defproject edu.ucdenver.ccp/kr-core "1.4.20-SNAPSHOT"
   :description "KR core API and tools."
-  :parent [edu.ucdenver.ccp/kr "1.4.20-SNAPSHOT" :relative-path "../pom.xml"]
   :parent-project {:path "../project.clj"
                    :inherit [:dependencies  :license]
                    :only-deps [org.clojure/clojure

--- a/kr-core/project.clj
+++ b/kr-core/project.clj
@@ -1,0 +1,11 @@
+(defproject edu.ucdenver.ccp/kr-core "1.4.20-SNAPSHOT"
+  :description "KR core API and tools."
+  :parent [edu.ucdenver.ccp/kr "1.4.20-SNAPSHOT" :relative-path "../pom.xml"]
+  :parent-project {:path "../project.clj"
+                   :inherit [:dependencies  :license]
+                   :only-deps [org.clojure/clojure
+                               org.clojure/java.classpath
+                               com.stuartsierra/dependency]}
+  :plugins [[lein-parent-mg "0.2.2"]]
+  :source-paths ["src/main/clojure" "src/test/clojure"]
+  :test-paths ["src/test/clojure"])

--- a/kr-jena/kr-jena-core/project.clj
+++ b/kr-jena/kr-jena-core/project.clj
@@ -5,7 +5,7 @@
                    :only-deps [org.clojure/clojure
                                org.apache.jena/jena-arq
                                com.stuartsierra/dependency]}
-  :plugins [[lein-parent-mg "0.2.2"]]
+  :plugins [[lein-parent "0.2.1"]]
   :profiles {:dev {:dependencies [[edu.ucdenver.ccp/kr-core "1.4.20-SNAPSHOT"]]}}
   :source-paths ["src/main/clojure"]
   :test-paths ["src/test/clojure"])

--- a/kr-jena/kr-jena-core/project.clj
+++ b/kr-jena/kr-jena-core/project.clj
@@ -1,6 +1,5 @@
 (defproject edu.ucdenver.ccp/kr-jena-core "1.4.20-SNAPSHOT"
   :description "KR Jena bindings."
-  :parent [edu.ucdenver.ccp/kr-jena "1.4.20-SNAPSHOT" :relative-path "../pom.xml"]
   :parent-project {:path "../../project.clj"
                    :inherit [:dependencies :license]
                    :only-deps [org.clojure/clojure

--- a/kr-jena/kr-jena-core/project.clj
+++ b/kr-jena/kr-jena-core/project.clj
@@ -1,0 +1,12 @@
+(defproject edu.ucdenver.ccp/kr-jena-core "1.4.20-SNAPSHOT"
+  :description "KR Jena bindings."
+  :parent [edu.ucdenver.ccp/kr-jena "1.4.20-SNAPSHOT" :relative-path "../pom.xml"]
+  :parent-project {:path "../../project.clj"
+                   :inherit [:dependencies :license]
+                   :only-deps [org.clojure/clojure
+                               org.apache.jena/jena-arq
+                               com.stuartsierra/dependency]}
+  :plugins [[lein-parent-mg "0.2.2"]]
+  :profiles {:dev {:dependencies [[edu.ucdenver.ccp/kr-core "1.4.20-SNAPSHOT"]]}}
+  :source-paths ["src/main/clojure"]
+  :test-paths ["src/test/clojure"])

--- a/kr-jena/project.clj
+++ b/kr-jena/project.clj
@@ -1,0 +1,4 @@
+(defproject edu.ucdenver.ccp/kr-jena "1.4.20-SNAPSHOT"
+  :description "KR Jena bindings."
+  :parent [edu.ucdenver.ccp/kr "1.4.20-SNAPSHOT" :relative-path "../pom.xml"]
+  :dependencies [edu.ucdenver.ccp/kr-sesame-core "1.4.20-SNAPSHOT"])

--- a/kr-jena/project.clj
+++ b/kr-jena/project.clj
@@ -1,4 +1,3 @@
 (defproject edu.ucdenver.ccp/kr-jena "1.4.20-SNAPSHOT"
   :description "KR Jena bindings."
-  :parent [edu.ucdenver.ccp/kr "1.4.20-SNAPSHOT" :relative-path "../pom.xml"]
   :dependencies [[edu.ucdenver.ccp/kr-jena-core "1.4.20-SNAPSHOT"]])

--- a/kr-jena/project.clj
+++ b/kr-jena/project.clj
@@ -1,4 +1,4 @@
 (defproject edu.ucdenver.ccp/kr-jena "1.4.20-SNAPSHOT"
   :description "KR Jena bindings."
   :parent [edu.ucdenver.ccp/kr "1.4.20-SNAPSHOT" :relative-path "../pom.xml"]
-  :dependencies [edu.ucdenver.ccp/kr-sesame-core "1.4.20-SNAPSHOT"])
+  :dependencies [[edu.ucdenver.ccp/kr-jena-core "1.4.20-SNAPSHOT"]])

--- a/kr-sesame/kr-sesame-core/project.clj
+++ b/kr-sesame/kr-sesame-core/project.clj
@@ -1,6 +1,5 @@
 (defproject edu.ucdenver.ccp/kr-sesame-core "1.4.20-SNAPSHOT"
   :description "KR Sesame bindings."
-  :parent [edu.ucdenver.ccp/kr-sesame "1.4.20-SNAPSHOT" :relative-path "../pom.xml"]
   :parent-project {:path "../../project.clj"
                    :inherit [:dependencies :license]
                    :only-deps [org.clojure/clojure

--- a/kr-sesame/kr-sesame-core/project.clj
+++ b/kr-sesame/kr-sesame-core/project.clj
@@ -1,0 +1,18 @@
+(defproject edu.ucdenver.ccp/kr-sesame-core "1.4.20-SNAPSHOT"
+  :description "KR Sesame bindings."
+  :parent [edu.ucdenver.ccp/kr-sesame "1.4.20-SNAPSHOT" :relative-path "../pom.xml"]
+  :parent-project {:path "../../project.clj"
+                   :inherit [:dependencies :license]
+                   :only-deps [org.clojure/clojure
+                               com.stuartsierra/dependency
+                               org.openrdf.sesame/sesame-runtime
+                               org.openrdf.sesame/sesame-queryresultio
+                               org.openrdf.sesame/sesame-queryresultio-sparqlxml
+                               org.openrdf.sesame/sesame-queryresultio-binary
+                               commons-logging
+                               commons-codec
+                               org.slf4j/slf4j-log4j12]}
+  :plugins [[lein-parent-mg "0.2.2"]]
+  :profiles {:test {:dependencies [[edu.ucdenver.ccp/kr-core "1.4.20-SNAPSHOT"]]}}
+  :source-paths ["src/main/clojure"]
+  :test-paths ["src/test/clojure"])

--- a/kr-sesame/kr-sesame-core/project.clj
+++ b/kr-sesame/kr-sesame-core/project.clj
@@ -11,7 +11,7 @@
                                commons-logging
                                commons-codec
                                org.slf4j/slf4j-log4j12]}
-  :plugins [[lein-parent-mg "0.2.2"]]
+  :plugins [[lein-parent "0.2.1"]]
   :profiles {:test {:dependencies [[edu.ucdenver.ccp/kr-core "1.4.20-SNAPSHOT"]]}}
   :source-paths ["src/main/clojure"]
   :test-paths ["src/test/clojure"])

--- a/kr-sesame/project.clj
+++ b/kr-sesame/project.clj
@@ -1,4 +1,4 @@
 (defproject edu.ucdenver.ccp/kr-sesame "1.4.20-SNAPSHOT"
   :description "KR Sesame bindings."
   :parent [edu.ucdenver.ccp/kr "1.4.20-SNAPSHOT" :relative-path "../pom.xml"]
-  :dependencies [edu.ucdenver.ccp/kr-sesame-core "1.4.20-SNAPSHOT"])
+  :dependencies [[edu.ucdenver.ccp/kr-sesame-core "1.4.20-SNAPSHOT"]])

--- a/kr-sesame/project.clj
+++ b/kr-sesame/project.clj
@@ -1,0 +1,4 @@
+(defproject edu.ucdenver.ccp/kr-sesame "1.4.20-SNAPSHOT"
+  :description "KR Sesame bindings."
+  :parent [edu.ucdenver.ccp/kr "1.4.20-SNAPSHOT" :relative-path "../pom.xml"]
+  :dependencies [edu.ucdenver.ccp/kr-sesame-core "1.4.20-SNAPSHOT"])

--- a/kr-sesame/project.clj
+++ b/kr-sesame/project.clj
@@ -1,4 +1,3 @@
 (defproject edu.ucdenver.ccp/kr-sesame "1.4.20-SNAPSHOT"
   :description "KR Sesame bindings."
-  :parent [edu.ucdenver.ccp/kr "1.4.20-SNAPSHOT" :relative-path "../pom.xml"]
   :dependencies [[edu.ucdenver.ccp/kr-sesame-core "1.4.20-SNAPSHOT"]])

--- a/project.clj
+++ b/project.clj
@@ -1,0 +1,20 @@
+(defproject edu.ucdenver.ccp/kr "1.4.20-SNAPSHOT"
+  :description "knowledge representation and reasoning tools"
+  :url "https://github.com/drlivingston/kr"
+  :license {:name "Eclipse Public License 1.0"
+            :url "http://opensource.org/licenses/eclipse-1.0.php"
+            :distribution "open"}
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [org.clojure/java.classpath "0.2.2"]
+                 [org.openrdf.sesame/sesame-runtime "2.7.13"]
+                 [org.openrdf.sesame/sesame-queryresultio "2.7.13" :extension "pom"]
+                 [org.openrdf.sesame/sesame-queryresultio-sparqlxml "2.7.13"]
+                 [org.openrdf.sesame/sesame-queryresultio-binary "2.7.13"]
+                 [org.apache.jena/jena-arq "2.12.1"]
+                 [log4j "1.2.17"]
+                 [commons-logging "1.1.1"]
+                 [commons-codec "1.6"]
+                 [com.stuartsierra/dependency "0.1.1"]
+                 [org.slf4j/slf4j-log4j12 "1.6.5"]]
+  :pom-plugins [[com.theoryinpractcise/clojure-maven-plugin "1.3.9"]]
+  :profiles {:test {:dependencies [[junit "3.8.1"]]}})

--- a/project.clj
+++ b/project.clj
@@ -16,5 +16,8 @@
                  [commons-codec "1.6"]
                  [com.stuartsierra/dependency "0.1.1"]
                  [org.slf4j/slf4j-log4j12 "1.6.5"]]
+  :plugins [[lein-sub "0.3.0"]]
   :pom-plugins [[com.theoryinpractcise/clojure-maven-plugin "1.3.9"]]
-  :profiles {:test {:dependencies [[junit "3.8.1"]]}})
+  :profiles {:test {:dependencies [[junit "3.8.1"]]}}
+  :sub ["kr-core" "kr-jena/kr-jena-core" "kr-jena"
+        "kr-sesame/kr-sesame-core" "kr-sesame"])


### PR DESCRIPTION
For my own work, I found it helpful to create Leiningen projects for KR. I discovered some rather old dependencies in KR while doing this, so I went ahead and bumped those. Somewhat poor form to do both of these things in a single PR, admittedly. My apologies for that.

Submitting this as a PR in case it is of some use.

Note: if you use any pom-generating lein tasks - install, deploy, etc - it will overwrite the existing poms.
